### PR TITLE
WSC 6.1: Version 1.2.0

### DIFF
--- a/.github/workflows/codestyle.yml
+++ b/.github/workflows/codestyle.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Setup PHP with tools
       uses: shivammathur/setup-php@v2
       with:
-        php-version: '8.2'
+        php-version: '8.1'
         extensions: ctype, dom, exif, gd, gmp, hash, intl, json, libxml, mbstring, opcache, pcre, pdo, pdo_mysql, zlib
         tools: cs2pr, phpcs, php-cs-fixer
     - name: phpcs

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -14,6 +14,7 @@ jobs:
         php:
         - '8.1'
         - '8.2'
+        - '8.3'
     steps:
     - name: Set up PHP
       uses: shivammathur/setup-php@v2

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -12,8 +12,6 @@ jobs:
       fail-fast: false
       matrix:
         php:
-        - '7.4'
-        - '8.0'
         - '8.1'
         - '8.2'
     steps:

--- a/files/lib/system/option/FediverseUserOptionType.class.php
+++ b/files/lib/system/option/FediverseUserOptionType.class.php
@@ -66,7 +66,7 @@ final class FediverseUserOptionType extends TextOptionType
         ]);
     }
 
-    private function getLink($value)
+    private function getLink($value): string
     {
         if (
             \preg_match(

--- a/files/lib/system/option/FediverseUserOptionType.class.php
+++ b/files/lib/system/option/FediverseUserOptionType.class.php
@@ -25,7 +25,7 @@ final class FediverseUserOptionType extends TextOptionType
         try {
             $data = JSON::decode($value);
             $value = $data['value'];
-        } catch (SystemException $e) {
+        } catch (SystemException) {
             $value = '';
         }
 
@@ -57,7 +57,7 @@ final class FediverseUserOptionType extends TextOptionType
             if (isset($optionData['value']) && $optionData['value'] === $newValue) {
                 return $fediverseData;
             }
-        } catch (SystemException $e) {
+        } catch (SystemException) {
         }
 
         return JSON::encode([

--- a/files/lib/system/option/FediverseUserOptionType.class.php
+++ b/files/lib/system/option/FediverseUserOptionType.class.php
@@ -5,6 +5,7 @@ namespace wcf\system\option;
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Psr7\Request;
 use Laminas\Diactoros\Uri;
+use Override;
 use Throwable;
 use wcf\data\option\Option;
 use wcf\system\exception\SystemException;
@@ -18,9 +19,7 @@ final class FediverseUserOptionType extends TextOptionType
 
     private string $error;
 
-    /**
-     * @inheritDoc
-     */
+    #[Override]
     public function getFormElement(Option $option, $value)
     {
         try {
@@ -33,9 +32,7 @@ final class FediverseUserOptionType extends TextOptionType
         return parent::getFormElement($option, $value);
     }
 
-    /**
-     * @inheritDoc
-     */
+    #[Override]
     public function validate(Option $option, $newValue)
     {
         parent::validate($option, $newValue);
@@ -45,9 +42,7 @@ final class FediverseUserOptionType extends TextOptionType
         }
     }
 
-    /**
-     * @inheritDoc
-     */
+    #[Override]
     public function getData(Option $option, $newValue)
     {
         // Check if the value is empty

--- a/files/lib/system/option/user/FediverseUserOptionOutput.class.php
+++ b/files/lib/system/option/user/FediverseUserOptionOutput.class.php
@@ -2,6 +2,7 @@
 
 namespace wcf\system\option\user;
 
+use Override;
 use wcf\data\user\option\UserOption;
 use wcf\data\user\User;
 use wcf\system\exception\SystemException;
@@ -10,9 +11,7 @@ use wcf\util\StringUtil;
 
 final class FediverseUserOptionOutput implements IUserOptionOutput
 {
-    /**
-     * @inheritDoc
-     */
+    #[Override]
     public function getOutput(User $user, UserOption $option, $value)
     {
         if ($value === null || $value === '') {

--- a/files/lib/system/option/user/FediverseUserOptionOutput.class.php
+++ b/files/lib/system/option/user/FediverseUserOptionOutput.class.php
@@ -22,7 +22,7 @@ final class FediverseUserOptionOutput implements IUserOptionOutput
             $data = JSON::decode($value);
 
             return StringUtil::getAnchorTag($data['href'], $data['value']);
-        } catch (SystemException $e) {
+        } catch (SystemException) {
             return '';
         }
     }

--- a/package.xml
+++ b/package.xml
@@ -1,32 +1,30 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<package xmlns="http://www.woltlab.com" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.woltlab.com http://www.woltlab.com/XSD/5.4/package.xsd" name="dev.hanashi.wsc.fediverse-profile-field">
+<package xmlns="http://www.woltlab.com" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.woltlab.com http://www.woltlab.com/XSD/6.0/package.xsd" name="dev.hanashi.wsc.fediverse-profile-field">
 	<packageinformation>
 		<!-- dev.hanashi.wsc.fediverse-profile-field -->
 		<packagename>Fediverse Profile Field</packagename>
 		<packagename language="de">Fediverse Profilfeld</packagename>
 		<packagedescription>Profile field for the Fediverse</packagedescription>
 		<packagedescription language="de">Profilfeld für des Fediverse</packagedescription>
-		<version>1.1.0</version>
-		<date>2023-11-12</date>
+		<version>1.2.0</version>
+		<date>2024-08-08</date>
 	</packageinformation>
 	<authorinformation>
 		<author>Hanashi Development</author>
 		<authorurl>https://hanashi.dev</authorurl>
 	</authorinformation>
 	<requiredpackages>
-		<requiredpackage minversion="5.5.16">com.woltlab.wcf</requiredpackage>
+		<requiredpackage minversion="6.1.0 Alpha 1">com.woltlab.wcf</requiredpackage>
 	</requiredpackages>
 	<excludedpackages>
-		<excludedpackage version="6.1.0 Alpha 1">com.woltlab.wcf</excludedpackage>
+		<excludedpackage version="6.2.0 Alpha 1">com.woltlab.wcf</excludedpackage>
 	</excludedpackages>
 	<instructions type="install">
 		<instruction type="file"/>
 		<instruction type="userOption"/>
 		<instruction type="language"/>
 	</instructions>
-	<instructions type="update" fromversion="1.0.1">
+	<instructions type="update" fromversion="1.1.*">
 		<instruction type="file"/>
-		<instruction type="userOption"/>
-		<instruction type="language"/>
 	</instructions>
 </package>

--- a/package.xml
+++ b/package.xml
@@ -7,14 +7,14 @@
 		<packagedescription>Profile field for the Fediverse</packagedescription>
 		<packagedescription language="de">Profilfeld für des Fediverse</packagedescription>
 		<version>1.2.0</version>
-		<date>2024-08-08</date>
+		<date>2024-09-02</date>
 	</packageinformation>
 	<authorinformation>
 		<author>Hanashi Development</author>
 		<authorurl>https://hanashi.dev</authorurl>
 	</authorinformation>
 	<requiredpackages>
-		<requiredpackage minversion="6.1.0 Alpha 1">com.woltlab.wcf</requiredpackage>
+		<requiredpackage minversion="6.1.0 Beta 1">com.woltlab.wcf</requiredpackage>
 	</requiredpackages>
 	<excludedpackages>
 		<excludedpackage version="6.2.0 Alpha 1">com.woltlab.wcf</excludedpackage>


### PR DESCRIPTION
Version für WSC 6.1

**Technische Änderungen**

- `#[Override]` wurde zu Kind-Methoden hinzugefügt, die Methoden aus Elternklassen überschreiben
- leichte Codeanpassungen